### PR TITLE
Change XRP chain name to Ripple

### DIFF
--- a/common/chain.go
+++ b/common/chain.go
@@ -72,7 +72,7 @@ var chainToString = map[Chain]string{
 	Ton:          "TON",
 	Terra:        "Terra",
 	TerraClassic: "TerraClassic",
-	XRP:          "XRP",
+	XRP:          "Ripple",
 	Osmosis:      "Osmosis",
 	Noble:        "Noble",
 	Tron:         "Tron",


### PR DESCRIPTION
Edits xrp name to ripple as commented in [#169](https://github.com/vultisig/recipes/pull/169)
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Updated the displayed name of the XRP chain to “Ripple” across the app. Any string outputs will now show “Ripple” instead of “XRP”.
  - Text-based inputs and conversions now recognize “Ripple” accordingly.
  - No changes to other chains; their labels and behavior remain the same.
  - This is a display/label update only; functionality and workflows are unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->