### PR TITLE
fix(address): length-guard EdDSA pubkeys at dispatch boundary

### DIFF
--- a/address/address.go
+++ b/address/address.go
@@ -9,17 +9,59 @@ import (
 )
 
 // GetAddress returns the address, public key, isEdDSA, and error for the given public key and chain.
+//
+// `rootHexPublicKey` is interpreted PER CHAIN FAMILY:
+//   - For ECDSA chains (Bitcoin, EVM, Cosmos-family, Tron, XRP, …) it MUST
+//     be the 33-byte (66 hex chars) compressed secp256k1 root pubkey. The
+//     function then BIP-32 derives along `chain.GetDerivePath()`.
+//   - For EdDSA chains (Solana, Sui, Polkadot, Ton, Cardano, Bittensor) it
+//     MUST be the 32-byte (64 hex chars) Ed25519 root pubkey. It is used
+//     directly with NO derivation step (Vultisig's MPC stack treats the
+//     EdDSA share's root key as the wallet key for these chains).
+//
+// **Common bug shape** (caught 2026-05-22 in agent-backend's `addressbook`
+// path): callers that only have the ECDSA pubkey on hand passed it for
+// EdDSA chains too. The chain-specific helpers (`GetSolAddress`,
+// `GetSuiAddress`, `GetDotAddress`, `GetBittensorAddress`) blindly
+// base58/blake2b'd whatever bytes they got, silently producing addresses
+// that decode to the ECDSA pubkey — confidently wrong, no error surfaced.
+// The 33-vs-32 byte length guards below catch the misuse at the dispatch
+// boundary so the failure is loud and actionable instead of garbage data
+// in `user_addresses`.
 func GetAddress(rootHexPublicKey string, rootChainCode string, chain common.Chain) (address string, publicKey string, isEdDSA bool, err error) {
 	if len(rootHexPublicKey) != 66 && len(rootHexPublicKey) != 64 {
 		return "", "", false, fmt.Errorf("invalid public key: %s", rootHexPublicKey)
 	}
 
 	if !chain.IsEdDSA() {
+		// ECDSA chains require the 33-byte (66 hex chars) compressed
+		// secp256k1 root pubkey. A caller that passes a 32-byte EdDSA
+		// pubkey here would silently re-derive nonsense via BIP-32.
+		if len(rootHexPublicKey) != 66 {
+			return "", "", false, fmt.Errorf(
+				"ECDSA chain %q requires a 33-byte (66 hex chars) compressed secp256k1 root pubkey, got %d hex chars",
+				chain, len(rootHexPublicKey),
+			)
+		}
 		publicKey, err = tss.GetDerivedPubKey(rootHexPublicKey, rootChainCode, chain.GetDerivePath(), chain.IsEdDSA())
 		if err != nil {
 			return "", "", false, fmt.Errorf("failed to derive public key: %w", err)
 		}
 	} else {
+		// EdDSA chains require the 32-byte (64 hex chars) Ed25519 root
+		// pubkey. A caller that passes the 33-byte ECDSA pubkey here is
+		// the bug shape from agent-backend's pre-2026-05 addressbook
+		// path — every Solana / Sui / Polkadot / Ton / Cardano /
+		// Bittensor address it stored was the ECDSA pubkey
+		// base58/blake2b'd. Fail loud rather than emit a confidently-
+		// wrong address that decodes to a real-looking string but
+		// belongs to no on-chain account.
+		if len(rootHexPublicKey) != 64 {
+			return "", "", false, fmt.Errorf(
+				"EdDSA chain %q requires a 32-byte (64 hex chars) Ed25519 root pubkey, got %d hex chars (a compressed ECDSA pubkey was passed instead?)",
+				chain, len(rootHexPublicKey),
+			)
+		}
 		publicKey = rootHexPublicKey
 	}
 

--- a/address/address_test.go
+++ b/address/address_test.go
@@ -99,3 +99,57 @@ func TestGetAddress(t *testing.T) {
 		})
 	}
 }
+
+// Regression pin for the 2026-05-22 bug shape: callers (notably
+// agent-backend's `addressbook.DeriveAndStore`) were passing the
+// 33-byte compressed ECDSA pubkey for EdDSA chains. Pre-fix, the
+// chain-specific helpers (`GetSolAddress`, `GetSuiAddress`, etc.)
+// happily base58/blake2b'd the ECDSA bytes and produced
+// confidently-wrong addresses (44 chars for Solana, 64 hex chars
+// for Sui, etc.) that decoded to the ECDSA pubkey itself — every
+// Solana / Sui / Polkadot / Ton / Cardano / Bittensor row in
+// `user_addresses` was garbage. Now `GetAddress` rejects the
+// 33-byte-for-EdDSA shape at the dispatch boundary so a missing
+// EdDSA pubkey surface in the caller fails loud.
+func TestGetAddress_RejectsECDSAPubkeyOnEdDSAChain(t *testing.T) {
+	edDSAChains := []common.Chain{
+		common.Solana,
+		common.Sui,
+		common.Polkadot,
+		common.Bittensor,
+		common.Ton,
+		common.Cardano,
+	}
+	for _, chain := range edDSAChains {
+		t.Run(chain.String(), func(t *testing.T) {
+			// Passing the 66-hex (33-byte) ECDSA root pubkey to an
+			// EdDSA chain MUST fail — that's the bug shape.
+			_, _, _, err := GetAddress(testECDSAPublicKey, testHexChainCode, chain)
+			if err == nil {
+				t.Fatalf("expected error rejecting 33-byte ECDSA pubkey for EdDSA chain %q, got nil", chain)
+			}
+			assert.Contains(t, err.Error(), "Ed25519")
+		})
+	}
+}
+
+func TestGetAddress_RejectsEdDSAPubkeyOnECDSAChain(t *testing.T) {
+	ecdsaChains := []common.Chain{
+		common.Bitcoin,
+		common.Ethereum,
+		common.GaiaChain,
+		common.Tron,
+	}
+	for _, chain := range ecdsaChains {
+		t.Run(chain.String(), func(t *testing.T) {
+			// Passing the 64-hex (32-byte) EdDSA root pubkey to an
+			// ECDSA chain MUST fail — symmetric to the EdDSA-on-
+			// ECDSA-chain case above.
+			_, _, _, err := GetAddress(testEdDSAPublicKey, testHexChainCode, chain)
+			if err == nil {
+				t.Fatalf("expected error rejecting 32-byte EdDSA pubkey for ECDSA chain %q, got nil", chain)
+			}
+			assert.Contains(t, err.Error(), "secp256k1")
+		})
+	}
+}

--- a/address/bittensor.go
+++ b/address/bittensor.go
@@ -5,10 +5,19 @@ import (
 	"fmt"
 )
 
+// GetBittensorAddress SS58-encodes a 32-byte Ed25519 pubkey as a
+// Bittensor address (network prefix 42). Length guard catches the
+// ECDSA-mistaken-for-EdDSA bug — see `GetSolAddress` for full rationale.
 func GetBittensorAddress(hexPublicKey string) (string, error) {
 	pubKeyBytes, err := hex.DecodeString(hexPublicKey)
 	if err != nil {
 		return "", fmt.Errorf("invalid derived EdDSA public key: %w", err)
+	}
+	if len(pubKeyBytes) != 32 {
+		return "", fmt.Errorf(
+			"Bittensor requires a 32-byte Ed25519 public key, got %d bytes (passed a compressed ECDSA pubkey instead?)",
+			len(pubKeyBytes),
+		)
 	}
 	return SS58Encode(pubKeyBytes, 42)
 }

--- a/address/dot.go
+++ b/address/dot.go
@@ -5,10 +5,20 @@ import (
 	"fmt"
 )
 
+// GetDotAddress SS58-encodes a 32-byte Ed25519 pubkey as a Polkadot
+// mainnet address (network prefix 0). Length guard catches the
+// ECDSA-pubkey-mistaken-for-EdDSA bug — see `GetSolAddress` for the
+// full rationale.
 func GetDotAddress(hexPublicKey string) (string, error) {
 	pubKeyBytes, err := hex.DecodeString(hexPublicKey)
 	if err != nil {
 		return "", fmt.Errorf("invalid derived EdDSA public key: %w", err)
+	}
+	if len(pubKeyBytes) != 32 {
+		return "", fmt.Errorf(
+			"Polkadot requires a 32-byte Ed25519 public key, got %d bytes (passed a compressed ECDSA pubkey instead?)",
+			len(pubKeyBytes),
+		)
 	}
 	return SS58Encode(pubKeyBytes, 0)
 }

--- a/address/sol.go
+++ b/address/sol.go
@@ -7,10 +7,26 @@ import (
 	"github.com/cosmos/btcutil/base58"
 )
 
+// GetSolAddress encodes a 32-byte Ed25519 pubkey as a Solana base58 address.
+//
+// The length guard catches the bug shape where a 33-byte compressed
+// secp256k1 (ECDSA) pubkey was passed instead of the 32-byte Ed25519
+// pubkey: pre-guard, the function happily base58-encoded the ECDSA
+// bytes and produced a 44-char string that LOOKS like a Solana address
+// but is actually the ECDSA pubkey. Solana RPC then rejected every
+// lookup with `Invalid param: WrongSize`. Fail loud at this layer too —
+// `GetAddress` already guards at the dispatch boundary, but this
+// helper is callable directly and shouldn't silently misbehave.
 func GetSolAddress(hexPublicKey string) (string, error) {
 	pubKeyBytes, err := hex.DecodeString(hexPublicKey)
 	if err != nil {
 		return "", fmt.Errorf("invalid derived EdDSA public key: %w", err)
+	}
+	if len(pubKeyBytes) != 32 {
+		return "", fmt.Errorf(
+			"Solana requires a 32-byte Ed25519 public key, got %d bytes (passed a compressed ECDSA pubkey instead?)",
+			len(pubKeyBytes),
+		)
 	}
 	return base58.Encode(pubKeyBytes), nil
 }

--- a/address/sui.go
+++ b/address/sui.go
@@ -7,18 +7,28 @@ import (
 	"golang.org/x/crypto/blake2b"
 )
 
-// GetSuiAddress generates a Sui address from a hex-encoded public key
+// GetSuiAddress generates a Sui address from a 32-byte Ed25519 public key.
+//
+// Sui addresses are blake2b-256(0x00 || pubkey) hex-encoded with `0x`
+// prefix. The 32-byte length guard catches the bug shape where a
+// 33-byte ECDSA pubkey was passed: pre-guard, the function happily
+// blake2b'd the ECDSA bytes and produced an indistinguishable-looking
+// 64-hex-char string that no real Sui account holds.
 func GetSuiAddress(hexPublicKey string) (string, error) {
-	// Decode the hex-encoded public key
 	pubKeyBytes, err := hex.DecodeString(hexPublicKey)
 	if err != nil {
 		return "", fmt.Errorf("invalid public key: %w", err)
+	}
+	if len(pubKeyBytes) != 32 {
+		return "", fmt.Errorf(
+			"Sui requires a 32-byte Ed25519 public key, got %d bytes (passed a compressed ECDSA pubkey instead?)",
+			len(pubKeyBytes),
+		)
 	}
 	toHash := make([]byte, 0, len(pubKeyBytes)+1)
 	toHash = append(toHash, 0x00)
 	toHash = append(toHash, pubKeyBytes...)
 	hashed := blake2b.Sum256(toHash)
-	// Convert the hashed public key to a Sui address
 	address := hex.EncodeToString(hashed[:])
 
 	return "0x" + address, nil


### PR DESCRIPTION
## Problem

`GetAddress` silently accepted a 33-byte compressed ECDSA pubkey for EdDSA chains (Solana, Sui, Polkadot, Ton, Cardano, Bittensor). The EdDSA branch set `publicKey = rootHexPublicKey` with NO length check, and each chain-specific helper then base58/blake2b'd the 33-byte ECDSA bytes verbatim.

Result, observed in production: every EdDSA address in agent-backend's `user_addresses` table for the active test vault decoded to the ECDSA pubkey itself:

```
ECDSA pubkey:         026d0128e1db1e19c982ce2d9b7964d3d6c229747dc369bbbfd3aa67a2fc1a9394
DB.Solana address:    io9CwpWo4MhawJPn4nr9pdRFk49yUgv1wQEhEnzY1okF
base58-decode(addr) = 026d0128e1db1e19c982ce2d9b7964d3d6c229747dc369bbbfd3aa67a2fc1a9394  ← same bytes
```

Solana RPC then rejected every lookup with `Invalid param: WrongSize`. App-side shows the correct address (`6HYauF…du1b`); agent-backend's stored copy was garbage, silent.

## Fix (this PR — defensive layer only)

Explicit length guards in two layers:

1. `GetAddress` (dispatch boundary): reject 33-byte input for EdDSA chains with a clear error message that names the cause ("passed a compressed ECDSA pubkey?"). Also reject 32-byte input for ECDSA chains, symmetric.
2. `GetSolAddress` / `GetSuiAddress` / `GetDotAddress` / `GetBittensorAddress`: add the same 32-byte length check, belt-and-braces. (`GetTonAddress` and `GetCardanoAddress` already had it; mirroring the pattern.)

## Why guard at both layers

`GetAddress` is where the caller's mistake originates and is the right place to catch the bug at the dispatch boundary. But the chain helpers are exported and callable directly; a downstream that bypasses `GetAddress` shouldn't silently produce garbage either.

## Regression pins

Two new test functions in `address_test.go`:
- `TestGetAddress_RejectsECDSAPubkeyOnEdDSAChain` — iterates all 6 EdDSA chains (Solana, Sui, Polkadot, Bittensor, Ton, Cardano), asserts 33-byte input throws with 'Ed25519' in the message.
- `TestGetAddress_RejectsEdDSAPubkeyOnECDSAChain` — symmetric for 4 ECDSA chains (Bitcoin, Ethereum, GaiaChain, Tron), asserts 32-byte input throws with 'secp256k1'.

```
$ go test ./address/...
ok  	github.com/vultisig/vultisig-go/address	0.577s
```

`go vet ./...` clean. `go build ./...` clean.

## Out of scope — actual derivation fix

This PR makes the failure LOUD. It does NOT yet fix the upstream caller (agent-backend's `addressbook.DeriveAndStore` path) that's been passing the wrong key. That's a separate change — agent-backend either needs the per-chain pre-derived pubkeys passed in the auth payload (matching mcp-ts's `set_vault_info chain_public_keys` schema) OR needs to skip EdDSA-chain derivation entirely and source addresses from the SDK on demand.

Tracking: `vultiagent-poc-uzv` bead.

## Migration

This is a breaking change for any caller using `GetAddress` on EdDSA chains with the wrong pubkey. By design — every such call was already producing garbage. Existing `user_addresses` rows downstream will need a one-shot re-derivation (or self-heal on next login once the caller is fixed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Strengthened public key format validation across blockchain address generation functions with clearer error messages to guide users when incorrect key types are provided.

* **Documentation**
  * Expanded inline documentation describing public key format requirements for each chain.

* **Tests**
  * Added regression tests for public key format validation across supported chains.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-go/pull/24?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->